### PR TITLE
Handle the (N,1) case in `get_lin_op`

### DIFF
--- a/convex/opts/sketchy_funcs.py
+++ b/convex/opts/sketchy_funcs.py
@@ -22,7 +22,9 @@ def get_lin_op(D, A, U, S, rho):
     def mv2_t(x):
         return A.T @ x
 
-    return LinearOperator((D.shape[0], U.shape[0]), matvec = lambda x: mv3(mv2(mv1(x))), rmatvec = lambda x: mv1(mv2_t(mv3(x))))
+    return LinearOperator((D.shape[0], U.shape[0]),
+                          matvec = lambda x: mv3(mv2(mv1(x.reshape(-1)))),
+                          rmatvec = lambda x: mv1(mv2_t(mv3(x.reshape(-1)))))
 
 def get_lin_op2(D, A, U, S):
     def mv(x):


### PR DESCRIPTION
Fix #1. According to the [document for `scipy.sparse.linalg.LinearOperator`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html):

> The user-defined matvec() function must properly handle the case where v has shape (N,) as well as the (N,1) case.

By adding `.reshape(-1)`, we ensure the input argument `x` is a 1D vector.

